### PR TITLE
fix: fix type mismatch

### DIFF
--- a/pkg/controller/github.go
+++ b/pkg/controller/github.go
@@ -131,8 +131,8 @@ func (gh *GitHub) GetRepo(ctx context.Context, repoOwner, repoName string) (Repo
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 	variables := map[string]any{
-		"owner": new(repoOwner),
-		"name":  new(repoName),
+		"owner": githubv4.String(repoOwner),
+		"name":  githubv4.String(repoName),
 	}
 
 	if err := gh.v4Client.Query(ctx, &q, variables); err != nil {


### PR DESCRIPTION
- https://github.com/aquaproj/user-list/actions/runs/25293090706/job/74147697216
- Bug of https://github.com/aquaproj/user-list/pull/2099/changes/9a102bf5123ded57f8f25cbee77dd70cfaff64ef

```
{"level":"fatal","error":"get a repository by GraphQL API: get a repository by GitHub GraphQL API: Type mismatch on variable $owner and argument owner (ID / String!)","time":"2026-05-03T22:49:54Z"}
```