### PR TITLE
fix: use org qualifier and tolerate GraphQL repo fetch errors

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -20,7 +20,7 @@ func (c *Controller) Run(ctx context.Context, logger zerolog.Logger) error {
 	gh := NewGitHub(ctx)
 	// query := "-user:suzuki-shunsuke -org:aquaproj aquaproj"
 	// Exclude aquasecurity due to IP restriction: https://github.com/aquaproj/user-list/issues/2101
-	query := "aquaproj/aqua-registry -owner:aquasecurity"
+	query := "aquaproj/aqua-registry -org:aquasecurity"
 	excludedOwners := map[string]struct{}{}
 
 	resultMap, err := gh.SearchRepos(ctx, logger, query, excludedOwners)

--- a/pkg/controller/github.go
+++ b/pkg/controller/github.go
@@ -98,8 +98,12 @@ func (gh *GitHub) SearchRepos(ctx context.Context, logger zerolog.Logger, query 
 			repoName := codeResult.Repository.GetName()
 			repo, err := gh.GetRepo(ctx, owner, repoName)
 			if err != nil {
-				// logger.Warn().Err(err).Msg("get a repository by GraphQL API")
-				return resultMap, fmt.Errorf("get a repository by GraphQL API: %w", err)
+				logger.Warn().Err(err).Msg("get a repository by GraphQL API")
+				resultMap[repoFullName] = &Result{
+					Repo: repoFullName,
+					Star: -1,
+				}
+				continue
 			}
 			logger.Info().Str("repo", repoFullName).Int("star", repo.Star).Send()
 			resultMap[repoFullName] = &Result{


### PR DESCRIPTION
## Summary

Two small robustness fixes to the aqua user-list crawler:

- **`pkg/controller/controller.go`** — The exclusion qualifier in the code-search query was wrong. GitHub code search supports `org:` / `user:` qualifiers, not `owner:`, so `-owner:aquasecurity` was being silently ignored and aquasecurity-owned repos were still being hit (the very thing #2102 / issue #2101 tried to avoid because of their IP restriction). Switch to `-org:aquasecurity` so the exclusion actually takes effect.
- **`pkg/controller/github.go`** — When the per-repo GraphQL call (`GetRepo`) failed for any single repository, `SearchRepos` returned the error and dropped every result it had already accumulated in this run. Replace the early return with a warning log and a placeholder `Result{Repo: repoFullName, Star: -1}` so the loop can keep going. The previously-commented `logger.Warn` line is restored as the actual handler. A `Star` value of `-1` flags the failed lookups so they're distinguishable from real zero-star repos downstream.

## Test plan

- [ ] Confirm `go build ./...` / `go vet ./...` pass
- [ ] Run the binary against GitHub and verify aquasecurity-owned repos are no longer included in the results
- [ ] Verify that a transient GraphQL failure on one repo no longer aborts the whole search (output still contains other repos, with the failing one listed at `-1` stars)
- [ ] CI (`list-aqua-users`) succeeds end-to-end — see #2105

🤖 Generated with [Claude Code](https://claude.com/claude-code)